### PR TITLE
Changed how value is set and what is displayed depending on the value type and Fixed ugly loop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.polychroma</groupId>
     <artifactId>configeditor</artifactId>
-    <version>1.0</version>
+    <version>1.2-densyakun</version>
     <packaging>jar</packaging>
 
     <name>Configeditor</name>

--- a/src/main/java/dev/polychroma/configeditor/command/ConfigEditCommand.java
+++ b/src/main/java/dev/polychroma/configeditor/command/ConfigEditCommand.java
@@ -45,10 +45,10 @@ public class ConfigEditCommand implements TabExecutor {
                     sender.sendMessage(getloadSyntax());
                     return true;
                 }
-                if (args.length == 3) {
-                    onLoadCommand(args[1], sender, args[2]);
-                } else {
+                if (args.length == 2) {
                     onLoadCommand(args[1], sender, null);
+                } else {
+                    onLoadCommand(args[1], sender, args[2]);
                 }
                 return true;
             }
@@ -86,7 +86,7 @@ public class ConfigEditCommand implements TabExecutor {
                     return true;
                 }
                 String pg;
-                if (args.length == 3) {
+                if (args.length >= 3) {
                     pg = args[2];
                 } else {
                     pg = "1";

--- a/src/main/java/dev/polychroma/configeditor/command/ConfigEditCommand.java
+++ b/src/main/java/dev/polychroma/configeditor/command/ConfigEditCommand.java
@@ -95,7 +95,7 @@ public class ConfigEditCommand implements TabExecutor {
                     pg = "1";
                 }
                 try {
-                    int page = Integer.parseInt(pg);
+                    int page = Integer.parseInt(pg) - 1;
                     onPrintCommand(args[1], sender, page);
                     return true;
                 } catch (NumberFormatException e) {
@@ -210,22 +210,14 @@ public class ConfigEditCommand implements TabExecutor {
         }
 
         YamlConfiguration config = configFiles.get(plugin).getRight();
-
-        //TODO: Fix ugly loop
-        int count = 0;
-        for (String key : config.getKeys(true)) {
-            if (count < (page - 1) * 15) {
-                count++;
-                continue;
-            }
-            if (count > page * 15) {
-                break;
-            }
-            sender.sendMessage(ChatUtils.MAIN_COLOR + translateKey(key) + ChatUtils.MESSAGE_COLOR + " - " + ChatUtils.SECONDARY_COLOR + config.get(key));
-            count++;
+        String[] configText = config.saveToString().split("\n");
+        for (int i = page * 15; i < (page + 1) * 15 && i < configText.length; i++) {
+            sender.sendMessage(ChatUtils.MESSAGE_COLOR + configText[i]);
         }
 
-        sender.sendMessage(ChatUtils.PREFIX + " " + ChatUtils.MESSAGE_COLOR + "To view the next page use /config print " + plugin + " " + ++page);
+        if ((page + 1) * 15 < configText.length) {
+            sender.sendMessage(ChatUtils.PREFIX + " " + ChatUtils.MESSAGE_COLOR + "To view the next page use /config print " + plugin + " " + (++page + 1));
+        }
     }
 
     private String translateKey(String key) {


### PR DESCRIPTION
Command examples:
- `config set <plugin> <key> null`
- `config set <plugin> <key> {"key1":"value1","key2":"value2"}`
- `config set <plugin> <key> 1` (int)
- `config set <plugin> <key> "1"` (string)